### PR TITLE
feat: add support for five OIDC-related Enterprise Cloud-only APIs and drop support for recently-added `POST /repos/:owner/:repo/dependency-graph/snapshots`, which is not GHEC-only

### DIFF
--- a/scripts/update-endpoints/generated/endpoints.json
+++ b/scripts/update-endpoints/generated/endpoints.json
@@ -277,6 +277,65 @@
   },
   {
     "scope": "actions",
+    "id": "getCustomOidcSubClaimForRepo",
+    "method": "GET",
+    "url": "/repos/{owner}/{repo}/actions/oidc/customization/sub",
+    "isDeprecated": false,
+    "documentationUrl": "https://docs.github.com/rest/actions/oidc#get-the-opt-out-flag-of-an-oidc-subject-claim-customization-for-a-repository",
+    "previews": [],
+    "headers": [],
+    "parameters": [
+      {
+        "name": "owner",
+        "in": "PATH",
+        "type": "string",
+        "required": true,
+        "enum": null,
+        "allowNull": false,
+        "mapToData": null,
+        "validation": null,
+        "alias": null,
+        "deprecated": null
+      },
+      {
+        "name": "repo",
+        "in": "PATH",
+        "type": "string",
+        "required": true,
+        "enum": null,
+        "allowNull": false,
+        "mapToData": null,
+        "validation": null,
+        "alias": null,
+        "deprecated": null
+      }
+    ],
+    "responses": [
+      {
+        "code": 200,
+        "examples": [
+          {
+            "data": "{\"use_default\":true}"
+          }
+        ]
+      },
+      {
+        "code": 400,
+        "examples": null
+      },
+      {
+        "code": 400,
+        "examples": null
+      },
+      {
+        "code": 404,
+        "examples": null
+      }
+    ],
+    "renamed": null
+  },
+  {
+    "scope": "actions",
     "id": "getSelfHostedRunnerGroupForOrg",
     "method": "GET",
     "url": "/orgs/{org}/actions/runner-groups/{runner_group_id}",
@@ -647,6 +706,120 @@
   },
   {
     "scope": "actions",
+    "id": "setActionsOidcCustomIssuerPolicyForEnterprise",
+    "method": "PUT",
+    "url": "/enterprises/{enterprise}/actions/oidc/customization/issuer",
+    "isDeprecated": false,
+    "documentationUrl": "https://docs.github.com/rest/reference/actions/oidc#set-actions-oidc-custom-issuer-policy-for-enterprise",
+    "previews": [],
+    "headers": [],
+    "parameters": [
+      {
+        "name": "enterprise",
+        "in": "PATH",
+        "type": "string",
+        "required": true,
+        "enum": null,
+        "allowNull": false,
+        "mapToData": null,
+        "validation": null,
+        "alias": null,
+        "deprecated": null
+      },
+      {
+        "name": "include_enterprise_slug",
+        "in": "BODY",
+        "type": "boolean",
+        "required": false,
+        "enum": null,
+        "allowNull": false,
+        "mapToData": null,
+        "validation": null,
+        "alias": null,
+        "deprecated": null
+      }
+    ],
+    "responses": [
+      {
+        "code": 204,
+        "examples": null
+      }
+    ],
+    "renamed": null
+  },
+  {
+    "scope": "actions",
+    "id": "setCustomOidcSubClaimForRepo",
+    "method": "PUT",
+    "url": "/repos/{owner}/{repo}/actions/oidc/customization/sub",
+    "isDeprecated": false,
+    "documentationUrl": "https://docs.github.com/rest/actions/oidc#set-the-opt-out-flag-of-an-oidc-subject-claim-customization-for-a-repository",
+    "previews": [],
+    "headers": [],
+    "parameters": [
+      {
+        "name": "owner",
+        "in": "PATH",
+        "type": "string",
+        "required": true,
+        "enum": null,
+        "allowNull": false,
+        "mapToData": null,
+        "validation": null,
+        "alias": null,
+        "deprecated": null
+      },
+      {
+        "name": "repo",
+        "in": "PATH",
+        "type": "string",
+        "required": true,
+        "enum": null,
+        "allowNull": false,
+        "mapToData": null,
+        "validation": null,
+        "alias": null,
+        "deprecated": null
+      },
+      {
+        "name": "use_default",
+        "in": "BODY",
+        "type": "boolean",
+        "required": true,
+        "enum": null,
+        "allowNull": false,
+        "mapToData": null,
+        "validation": null,
+        "alias": null,
+        "deprecated": null
+      }
+    ],
+    "responses": [
+      {
+        "code": 201,
+        "examples": null
+      },
+      {
+        "code": 400,
+        "examples": null
+      },
+      {
+        "code": 400,
+        "examples": null
+      },
+      {
+        "code": 404,
+        "examples": null
+      },
+      {
+        "code": 422,
+        "examples": null
+      }
+    ],
+    "renamed": null
+  },
+  {
+    "scope": "actions",
     "id": "setRepoAccessToSelfHostedRunnerGroupInOrg",
     "method": "PUT",
     "url": "/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories",
@@ -965,317 +1138,6 @@
         "examples": [
           {
             "data": "{\"days_left_in_billing_cycle\":20,\"estimated_paid_storage_for_month\":15,\"estimated_storage_for_month\":40}"
-          }
-        ]
-      }
-    ],
-    "renamed": null
-  },
-  {
-    "scope": "dependencyGraph",
-    "id": "createRepositorySnapshot",
-    "method": "POST",
-    "url": "/repos/{owner}/{repo}/dependency-graph/snapshots",
-    "isDeprecated": false,
-    "documentationUrl": "https://docs.github.com/rest/reference/dependency-graph#create-a-snapshot-of-dependencies-for-a-repository",
-    "previews": [],
-    "headers": [],
-    "parameters": [
-      {
-        "name": "owner",
-        "in": "PATH",
-        "type": "string",
-        "required": true,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "repo",
-        "in": "PATH",
-        "type": "string",
-        "required": true,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "version",
-        "in": "BODY",
-        "type": "integer",
-        "required": true,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "job",
-        "in": "BODY",
-        "type": "object",
-        "required": true,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "job.id",
-        "in": "BODY",
-        "type": "string",
-        "required": true,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "job.correlator",
-        "in": "BODY",
-        "type": "string",
-        "required": true,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "job.html_url",
-        "in": "BODY",
-        "type": "string",
-        "required": false,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "sha",
-        "in": "BODY",
-        "type": "string",
-        "required": true,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "ref",
-        "in": "BODY",
-        "type": "string",
-        "required": true,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": "^refs/",
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "detector",
-        "in": "BODY",
-        "type": "object",
-        "required": true,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "detector.name",
-        "in": "BODY",
-        "type": "string",
-        "required": true,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "detector.version",
-        "in": "BODY",
-        "type": "string",
-        "required": true,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "detector.url",
-        "in": "BODY",
-        "type": "string",
-        "required": true,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "metadata",
-        "in": "BODY",
-        "type": "object",
-        "required": false,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "metadata.*",
-        "in": "BODY",
-        "type": "object",
-        "required": false,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "manifests",
-        "in": "BODY",
-        "type": "object",
-        "required": false,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "manifests.*",
-        "in": "BODY",
-        "type": "object",
-        "required": false,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "manifests.*.name",
-        "in": "BODY",
-        "type": "string",
-        "required": true,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "manifests.*.file",
-        "in": "BODY",
-        "type": "object",
-        "required": false,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "manifests.*.file.source_location",
-        "in": "BODY",
-        "type": "string",
-        "required": false,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "manifests.*.metadata",
-        "in": "BODY",
-        "type": "object",
-        "required": false,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "manifests.*.metadata.*",
-        "in": "BODY",
-        "type": "object",
-        "required": false,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "manifests.*.resolved",
-        "in": "BODY",
-        "type": null,
-        "required": false,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      },
-      {
-        "name": "scanned",
-        "in": "BODY",
-        "type": "string",
-        "required": true,
-        "enum": null,
-        "allowNull": false,
-        "mapToData": null,
-        "validation": null,
-        "alias": null,
-        "deprecated": null
-      }
-    ],
-    "responses": [
-      {
-        "code": 201,
-        "examples": [
-          {
-            "data": "{\"id\":12345,\"created_at\":\"2018-05-04T01:14:52Z\",\"message\":\"Dependency results for the repo have been successfully updated.\",\"result\":\"SUCCESS\"}"
           }
         ]
       }
@@ -3578,6 +3440,96 @@
             "data": "{\"id\":2,\"name\":\"Expensive hardware runners\",\"visibility\":\"selected\",\"default\":false,\"selected_organizations_url\":\"https://api.github.com/enterprises/octo-corp/actions/runner-groups/2/organizations\",\"runners_url\":\"https://api.github.com/enterprises/octo-corp/actions/runner-groups/2/runners\",\"allows_public_repositories\":true,\"restricted_to_workflows\":false,\"selected_workflows\":[\"octo-org/octo-repo/.github/workflows/deploy.yaml@refs/heads/main\"],\"workflow_restrictions_read_only\":false}"
           }
         ]
+      }
+    ],
+    "renamed": null
+  },
+  {
+    "scope": "oidc",
+    "id": "getOidcCustomSubTemplateForOrg",
+    "method": "GET",
+    "url": "/orgs/{org}/actions/oidc/customization/sub",
+    "isDeprecated": false,
+    "documentationUrl": "https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization",
+    "previews": [],
+    "headers": [],
+    "parameters": [
+      {
+        "name": "org",
+        "in": "PATH",
+        "type": "string",
+        "required": true,
+        "enum": null,
+        "allowNull": false,
+        "mapToData": null,
+        "validation": null,
+        "alias": null,
+        "deprecated": null
+      }
+    ],
+    "responses": [
+      {
+        "code": 200,
+        "examples": [
+          {
+            "data": "{\"include_claim_keys\":[\"repo\",\"context\"]}"
+          }
+        ]
+      }
+    ],
+    "renamed": null
+  },
+  {
+    "scope": "oidc",
+    "id": "updateOidcCustomSubTemplateForOrg",
+    "method": "PUT",
+    "url": "/orgs/{org}/actions/oidc/customization/sub",
+    "isDeprecated": false,
+    "documentationUrl": "https://docs.github.com/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-an-organization",
+    "previews": [],
+    "headers": [],
+    "parameters": [
+      {
+        "name": "org",
+        "in": "PATH",
+        "type": "string",
+        "required": true,
+        "enum": null,
+        "allowNull": false,
+        "mapToData": null,
+        "validation": null,
+        "alias": null,
+        "deprecated": null
+      },
+      {
+        "name": "include_claim_keys",
+        "in": "BODY",
+        "type": "string[]",
+        "required": true,
+        "enum": null,
+        "allowNull": false,
+        "mapToData": null,
+        "validation": null,
+        "alias": null,
+        "deprecated": null
+      }
+    ],
+    "responses": [
+      {
+        "code": 201,
+        "examples": [
+          {
+            "data": "null"
+          }
+        ]
+      },
+      {
+        "code": 403,
+        "examples": null
+      },
+      {
+        "code": 404,
+        "examples": null
       }
     ],
     "renamed": null

--- a/src/generated/endpoints.ts
+++ b/src/generated/endpoints.ts
@@ -13,6 +13,9 @@ const Endpoints: EndpointsDefaultsAndDecorations = {
     deleteSelfHostedRunnerGroupFromOrg: [
       "DELETE /orgs/:org/actions/runner-groups/:runner_group_id",
     ],
+    getCustomOidcSubClaimForRepo: [
+      "GET /repos/:owner/:repo/actions/oidc/customization/sub",
+    ],
     getSelfHostedRunnerGroupForOrg: [
       "GET /orgs/:org/actions/runner-groups/:runner_group_id",
     ],
@@ -28,6 +31,12 @@ const Endpoints: EndpointsDefaultsAndDecorations = {
     ],
     removeSelfHostedRunnerFromGroupForOrg: [
       "DELETE /orgs/:org/actions/runner-groups/:runner_group_id/runners/:runner_id",
+    ],
+    setActionsOidcCustomIssuerPolicyForEnterprise: [
+      "PUT /enterprises/:enterprise/actions/oidc/customization/issuer",
+    ],
+    setCustomOidcSubClaimForRepo: [
+      "PUT /repos/:owner/:repo/actions/oidc/customization/sub",
     ],
     setRepoAccessToSelfHostedRunnerGroupInOrg: [
       "PUT /orgs/:org/actions/runner-groups/:runner_group_id/repositories",
@@ -149,6 +158,14 @@ const Endpoints: EndpointsDefaultsAndDecorations = {
     ],
     updateSelfHostedRunnerGroupForEnterprise: [
       "PATCH /enterprises/:enterprise/actions/runner-groups/:runner_group_id",
+    ],
+  },
+  oidc: {
+    getOidcCustomSubTemplateForOrg: [
+      "GET /orgs/:org/actions/oidc/customization/sub",
+    ],
+    updateOidcCustomSubTemplateForOrg: [
+      "PUT /orgs/:org/actions/oidc/customization/sub",
     ],
   },
   orgs: {

--- a/src/generated/endpoints.ts
+++ b/src/generated/endpoints.ts
@@ -59,11 +59,6 @@ const Endpoints: EndpointsDefaultsAndDecorations = {
       "GET /enterprises/:enterprise/settings/billing/shared-storage",
     ],
   },
-  dependencyGraph: {
-    createRepositorySnapshot: [
-      "POST /repos/:owner/:repo/dependency-graph/snapshots",
-    ],
-  },
   enterpriseAdmin: {
     addOrgAccessToSelfHostedRunnerGroupInEnterprise: [
       "PUT /enterprises/:enterprise/actions/runner-groups/:runner_group_id/organizations/:org_id",


### PR DESCRIPTION
If you need `POST /repos/:owner/:repo/dependency-graph/snapshots`, it's now in https://github.com/octokit/plugin-rest-endpoint-methods.js, where it should have been all along