### PR TITLE
ci: stop testing against NodeJS v10, v12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,9 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 12
+          - 14
+          - 16
+          - 18
     steps:
       - uses: actions/checkout@master
       - name: Test with Node.js ${{ matrix.node_version }}

--- a/package.json
+++ b/package.json
@@ -70,7 +70,10 @@
         "@pika/plugin-ts-standard-pkg"
       ],
       [
-        "@pika/plugin-build-node"
+        "@pika/plugin-build-node",
+        {
+          "minNodeVersion": "14"
+        }
       ],
       [
         "@pika/plugin-build-web"
@@ -114,5 +117,8 @@
         ]
       }
     ]
+  },
+  "engines": {
+    "node": ">= 14"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS v10, v12