### PR TITLE
build(fetch-json): remove `v` from version string

### DIFF
--- a/scripts/update-endpoints/fetch-json.js
+++ b/scripts/update-endpoints/fetch-json.js
@@ -60,7 +60,7 @@ main();
 
 async function main() {
   const result = await graphql(QUERY, {
-    version: process.env.VERSION,
+    version: process.env.VERSION.replace(/^v/, ""),
     ignoreChangesBefore: "2021-06-27",
   });
 


### PR DESCRIPTION
This fixes the update workflow that has been failing recently