### PR TITLE
docs: replace references to Skypack CDN with esm.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@
 Browsers
 </th><td width=100%>
 
-Load `@octokit/plugin-enterprise-cloud` and [`@octokit/core`](https://github.com/octokit/core.js) (or core-compatible module) directly from [cdn.skypack.dev](https://cdn.skypack.dev)
+Load `@octokit/plugin-enterprise-cloud` and [`@octokit/core`](https://github.com/octokit/core.js) (or core-compatible module) directly from [esm.sh](https://esm.sh)
 
 ```html
 <script type="module">
-  import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
-  import { enterpriseCloud } from "https://cdn.skypack.dev/@octokit/plugin-enterprise-cloud";
+  import { Octokit } from "https://esm.sh/@octokit/core";
+  import { enterpriseCloud } from "https://esm.sh/@octokit/plugin-enterprise-cloud";
 </script>
 ```
 


### PR DESCRIPTION
The Skypack CDN is no longer maintained, so we should remove references to it.