### PR TITLE
refactor: use `node:` specifier imports and full relative path imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
         "functions": 100,
         "lines": 100
       }
+    },
+    "moduleNameMapper": {
+      "^(.+)\\.jsx?$": "$1"
     }
   },
   "release": {

--- a/scripts/update-endpoints/code.js
+++ b/scripts/update-endpoints/code.js
@@ -71,7 +71,7 @@ async function main() {
   writeFileSync(
     ROUTES_PATH,
     await prettier.format(
-      `import type { EndpointsDefaultsAndDecorations } from "../types";
+      `import type { EndpointsDefaultsAndDecorations } from "../types.js";
   const Endpoints: EndpointsDefaultsAndDecorations = ${JSON.stringify(
         sortKeys(newRoutes, { deep: true })
       )}

--- a/src/endpoints-to-methods.ts
+++ b/src/endpoints-to-methods.ts
@@ -6,7 +6,7 @@ import type {
   Route,
   Url,
 } from "@octokit/types";
-import type { EndpointsDefaultsAndDecorations } from "./types";
+import type { EndpointsDefaultsAndDecorations } from "./types.js";
 
 type EndpointMethods = {
   [methodName: string]: typeof Octokit.prototype.request;

--- a/src/generated/endpoints.ts
+++ b/src/generated/endpoints.ts
@@ -1,4 +1,4 @@
-import type { EndpointsDefaultsAndDecorations } from "../types";
+import type { EndpointsDefaultsAndDecorations } from "../types.js";
 const Endpoints: EndpointsDefaultsAndDecorations = {
   actions: {
     addRepoAccessToSelfHostedRunnerGroupInOrg: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import type { Octokit } from "@octokit/core";
 
-import ENDPOINTS from "./generated/endpoints";
-import { VERSION } from "./version";
-import { endpointsToMethods } from "./endpoints-to-methods";
+import ENDPOINTS from "./generated/endpoints.js";
+import { VERSION } from "./version.js";
+import { endpointsToMethods } from "./endpoints-to-methods.js";
 
 export function enterpriseCloud(octokit: Octokit) {
   return endpointsToMethods(octokit, ENDPOINTS);

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports.