### PR TITLE
maint: update workflows to use LTS Node & fix update workflow

### DIFF
--- a/.github/workflows/update-prettier.yml
+++ b/.github/workflows/update-prettier.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: npm
-          node-version: 16
+          node-version: "lts/*"
       - run: npm ci
       - run: npm run lint:fix
       - uses: gr2m/create-or-update-pull-request-action@v1.x

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -19,12 +19,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: "lts/*"
           cache: npm
       - run: git checkout routes-update || true
       - run: npm ci
+      - run: npm install @octokit/types@latest
+        if: >-
+          github.event_name == 'repository_dispatch' && github.event.action ==
+          'octokit/types.ts release'
       - run: npm run update-endpoints
-        if: github.event_name == 'repository_dispatch'
+        if:  >-
+          github.event_name == 'repository_dispatch' && github.event.action ==
+          'octokit/openapi release'
         env:
           VERSION: ${{ github.event.client_payload.release.tag_name }}
       - run: npm run update-endpoints


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The workflows would use Node 16 to run
* The update workflow would fail every time there was an `@octokit/types` release

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Use `lts/*` as the Node version instead of pinning to a specific version
* Add logic to update `@octokit/types`
* Add logic to prevent route updates to fire for an `@octokit/types` release

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

